### PR TITLE
ci(netlify): set Node version to latest lts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,10 @@
   command = "npm run prod && jekyll build"
   publish = "_site/"
 
+[build.environment]
+  NODE_VERSION = "14.15.1"
+  NETLIFY = "TRUE"
+
 [context.production.environment]
   JEKYLL_ENV = "production"
   NODE_ENV = "production"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "prod": "encore prod",
         "watch:webpack": "encore dev --watch",
         "watch:jekyll": "bundle exec jekyll serve --livereload --drafts --open",
-        "postinstall": "bundle install --path=vendor/bundle --jobs=4 --retry=3"
+        "postinstall": "test -n \"$NETLIFY\" || bundle install --path=vendor/bundle --jobs=4 --retry=3"
     },
     "dependencies": {
         "@symfony/webpack-encore": "^0.31.0",


### PR DESCRIPTION
Netlify defaults to Node 10, which might be causing the build issues. Set version to latest LTS via
environment variable.

Don't postinstall gems when running in Netlify. I think this is causing some cache issues and
leading to longer build times.